### PR TITLE
Fixed group name not being passed to wait_for_new_instances when replacing instances

### DIFF
--- a/cloud/amazon/ec2_asg.py
+++ b/cloud/amazon/ec2_asg.py
@@ -485,7 +485,7 @@ def replace(connection, module):
     replace_instances = module.params.get('replace_instances')
 
     as_group = connection.get_all_groups(names=[group_name])[0]
-    wait_for_new_instances(module, connection, as_group, wait_timeout, as_group.min_size, 'viable_instances')
+    wait_for_new_instances(module, connection, group_name, wait_timeout, as_group.min_size, 'viable_instances')
     props = get_properties(as_group)
     instances = props['instances']
     replaceable = 0
@@ -505,7 +505,7 @@ def replace(connection, module):
     as_group.min_size = min_size + batch_size
     as_group.desired_capacity = desired_capacity + batch_size
     as_group.update()
-    wait_for_new_instances(module, connection, as_group, wait_timeout, as_group.min_size, 'viable_instances')
+    wait_for_new_instances(module, connection, group_name, wait_timeout, as_group.min_size, 'viable_instances')
     wait_for_elb(connection, module, as_group)
     as_group = connection.get_all_groups(names=[group_name])[0]
     props = get_properties(as_group)
@@ -514,7 +514,7 @@ def replace(connection, module):
         instances = replace_instances
     for i in get_chunks(instances, batch_size):
         terminate_batch(connection, module, i)
-        wait_for_new_instances(module, connection,  as_group, wait_timeout, as_group.min_size, 'viable_instances')
+        wait_for_new_instances(module, connection, group_name, wait_timeout, as_group.min_size, 'viable_instances')
         wait_for_elb(connection, module, group_name)
         as_group = connection.get_all_groups(names=[group_name])[0]
     # return settings to normal

--- a/cloud/amazon/ec2_asg.py
+++ b/cloud/amazon/ec2_asg.py
@@ -506,7 +506,7 @@ def replace(connection, module):
     as_group.desired_capacity = desired_capacity + batch_size
     as_group.update()
     wait_for_new_instances(module, connection, group_name, wait_timeout, as_group.min_size, 'viable_instances')
-    wait_for_elb(connection, module, as_group)
+    wait_for_elb(connection, module, group_name)
     as_group = connection.get_all_groups(names=[group_name])[0]
     props = get_properties(as_group)
     instances = props['instances']
@@ -581,8 +581,7 @@ def wait_for_new_instances(module, connection, group_name, wait_timeout, desired
     wait_timeout = time.time() + wait_timeout
     while wait_timeout > time.time() and desired_size > props[prop]:
         time.sleep(10)
-        as_groups = connection.get_all_groups(names=[group_name])
-        as_group = as_groups[0]
+        as_group = connection.get_all_groups(names=[group_name])[0]
         props = get_properties(as_group)
     if wait_timeout <= time.time():
         # waiting took too long


### PR DESCRIPTION
When replacing instances the group_name parameter isn't being passed, as_group is instead.
